### PR TITLE
Implement options object for `attachToForm` method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+All notable changes to this library will be documented in this file.
+
+## 1.5.0 - 2019-03-08
+### Added
+- Introduce options object to `attachToForm` method
+- Introduce `preventSubmit` option
+
+## 1.4.0 - 2019-03-07
+### Added
+- Support for asynchronous validators

--- a/README.md
+++ b/README.md
@@ -85,11 +85,17 @@ init method or the constructor to a form.
 ```javascript
 const $form = document.querySelector('#my-form');
 const validators = Validator.init();
-Validator.attachToForm($form, validators);
+Validator.attachToForm($form, validators, {});
 ```
 
 This will check all validators, when the form is submitted and prevent the
 submit, if one of the validators fails.
+
+Additionally, the third argument of the `attachToForm` method is an options
+object that can be used to configure the behavior of the validation further.
+It can have the following options:
+
+ * `preventSubmit` (boolean, default: false) - prevents the submitting of the form, even if it is valid
 
 ### Configuration
 To validate an input, the library provides a set of basic validators that

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopmacher/validate",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Extensible JavaScript form validation library",
   "main": "lib/validate.js",
   "jsnext:main": "lib/validate.js",

--- a/src/core/Validator.js
+++ b/src/core/Validator.js
@@ -159,8 +159,11 @@ export default class Validator {
      *
      * @param $form
      * @param validators
+     * @param options
      */
-    static attachToForm($form, validators) {
+    static attachToForm($form, validators, options = {}) {
+        const { preventSubmit } = options;
+
         $form.addEventListener('submit', (event) => {
             event.preventDefault();
             const result$ = validators.map(validator => validator.validate(event, triggers.SUBMIT));
@@ -176,7 +179,9 @@ export default class Validator {
                     }
                 }));
 
-                $form.submit();
+                if (!preventSubmit) {
+                    $form.submit();
+                }
             });
         });
     }


### PR DESCRIPTION
Due the the case that the validator dispatches an event when validation
is finished, it might sometimes be required to rely only on the event
instead of the validator to submit the form automatically. This is made
possible by the `preventSubmit` boolean.